### PR TITLE
setSelector

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -438,6 +438,21 @@ define( [
             this.opts = $.extend.apply($, [true, {}].concat(this.optsCollector).concat([forcedOpts]));
         },
         /**
+         * Merge selectors into the selector dictionary (collector) used by _findLocalElems
+         * @param {object}  selectorsObj selectors dictionary
+         * @param {boolean} overwrite    overwrite stored selectors dictionary (forced)
+         */
+        setSelectors : function (selectorsObj, overwrite) {
+            this.S = this.S || {};
+            overwrite = !!overwrite || false;
+
+            if (overwrite) {
+                this.S = selectorsObj;
+            } else {
+                this.S = $.extend(true, {}, this.S, selectorsObj);
+            }
+        },
+        /**
          * Merge specific resources to the component resource map
          *
          * var RESOURCE_MAP = {
@@ -448,7 +463,6 @@ define( [
          *     appConfig : [],
          *     context : {}
          * };
-         }
          */
         addResources : function (resourceMap) {
             // $.extend does not support nested arrays merge


### PR DESCRIPTION
Lets improve how we define selectors

Instead of direct sets to this.S, it should be abstract (unknown implementation) and allow inheritance definitions.

Looking forward, we should also consider adding methods like this.getSelector(key) and hide also tags implementation this.t by another method like this.getTag(key)
